### PR TITLE
Fix deprecation of update_attributes!

### DIFF
--- a/lib/active_job_log/loggeable.rb
+++ b/lib/active_job_log/loggeable.rb
@@ -39,7 +39,7 @@ module ActiveJobLog
       def update_job!(job_id, status, params = {})
         params.merge!(status_to_params(status))
         job = find_or_create_job(job_id)
-        job.update_attributes!(params)
+        job.update!(params)
         job
       end
 


### PR DESCRIPTION
since rails 5.2: DEPRECATION WARNING: update_attributes! is deprecated and will be removed from Rails 6.1 (please, use update! instead)

This will break any support for anything pre rails 4 - not sure what your old rails support expectation is. Happy to adjust if earlier versions need support.

(travis wasn't kicking off after my remerge so I just recreated - this is the same fix as #28 )

thank you so much @jgmontoya !