### PR TITLE
Serialize method format compliant with 7.2 syntax

### DIFF
--- a/lib/active_job_log/loggeable.rb
+++ b/lib/active_job_log/loggeable.rb
@@ -11,8 +11,8 @@ module ActiveJobLog
 
       enumerize :status, in: STATUSES, scope: true
 
-      serialize :params, Array
-      serialize :stack_trace, Array
+      serialize :params, coder: JSON, type: Array
+      serialize :stack_trace, coder: JSON, type: Array
 
       before_save :set_queued_duration
       before_save :set_execution_duration


### PR DESCRIPTION
As per 

`DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.`

this pull request provides serialize options as keyword arguments instead of positional arguments.

This would close https://github.com/platanus/active_job_log/issues/74